### PR TITLE
Implement FEN board creation

### DIFF
--- a/src/main/kotlin/hwr/oop/ChessBoard.kt
+++ b/src/main/kotlin/hwr/oop/ChessBoard.kt
@@ -62,7 +62,48 @@ class ChessBoard(private val board: MutableMap<Position, Figure>) {
          */
         fun fromFEN(fenString: String): ChessBoard {
             val fen = FEN(fenString)
-            return ChessBoard(mutableMapOf())
+            val board = mutableMapOf<Position, Figure>()
+
+            val rows = fen.getPiecePlacement().split("/")
+            require(rows.size == 8) { "Invalid FEN: wrong row count" }
+
+            for ((rowIndex, rowStr) in rows.withIndex()) {
+                var colIndex = 0
+                for (char in rowStr) {
+                    when {
+                        char.isDigit() -> {
+                            colIndex += char.digitToInt()
+                        }
+                        else -> {
+                            val column = Column.values().getOrNull(colIndex)
+                                ?: throw IllegalArgumentException("Invalid FEN: row too long")
+                            val row = Row.values()[7 - rowIndex]
+                            val figure = when (char) {
+                                'b' -> Pawn(Color.WHITE)
+                                'B' -> Pawn(Color.BLACK)
+                                't' -> Rook(Color.WHITE)
+                                'T' -> Rook(Color.BLACK)
+                                's' -> Knight(Color.WHITE)
+                                'S' -> Knight(Color.BLACK)
+                                'l' -> Bishop(Color.WHITE)
+                                'L' -> Bishop(Color.BLACK)
+                                'd' -> Queen(Color.WHITE)
+                                'D' -> Queen(Color.BLACK)
+                                'k' -> King(Color.WHITE)
+                                'K' -> King(Color.BLACK)
+                                else -> throw IllegalArgumentException("Invalid figure in FEN: $char")
+                            }
+                            board[Position(column, row)] = figure
+                            colIndex++
+                        }
+                    }
+                }
+                if (colIndex != 8) {
+                    throw IllegalArgumentException("Invalid FEN: row length not 8")
+                }
+            }
+
+            return ChessBoard(board)
         }
     }
 

--- a/src/test/kotlin/hwr/oop/ChessBoardTests.kt
+++ b/src/test/kotlin/hwr/oop/ChessBoardTests.kt
@@ -27,14 +27,22 @@ class ChessBoardTests : AnnotationSpec() {
     }
 
     @Test
+    fun `fromFEN builds board correctly for full board`() {
+        val fenString = "TSLDKLST/BBBBBBBB/8/8/8/8/bbbbbbbb/tsldklst w KQkq - 0 1"
+        val board = ChessBoard.fromFEN(fenString)
+
+        assertThat(board.getFigureAt(Position(Column.A, Row.EIGHT))).isInstanceOf(Rook::class.java)
+        assertThat(board.getFigureAt(Position(Column.E, Row.ONE))).isInstanceOf(King::class.java)
+        assertThat(board.getFigureAt(Position(Column.A, Row.TWO))).isInstanceOf(Pawn::class.java)
+        assertThat(board.getAllPositions().size).isEqualTo(32)
+    }
+
+    @Test
     fun `fromFEN throws IllegalArgumentException for invalid FEN`() {
         val invalidFEN = "invalidFENString"
-
-        val exception = assertThrows<IllegalArgumentException> {
+        assertThrows<IllegalArgumentException> {
             ChessBoard.fromFEN(invalidFEN)
         }
-
-        assertThat(exception.message?.contains("Invalid figure in FEN") == true)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- build chessboard from FEN strings
- validate input of FEN parsing
- verify board build in tests
- expect error on invalid FEN

## Testing
- `./mvnw -DskipTests=false test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684d71666804832e8c83a685d46846a7